### PR TITLE
Set file content type before post-processing to override setting default content type

### DIFF
--- a/app/controllers/spree/admin/product_imports_controller.rb
+++ b/app/controllers/spree/admin/product_imports_controller.rb
@@ -12,7 +12,7 @@ module Spree
           flash[:notice] = 'Please refresh while status is pending or processing'
           redirect_to admin_product_import_path(file_import)
         else
-          flash[:error] = "#{ file_import.errors.full_messages.join }.
+          flash[:error] = "#{ file_import.errors.full_messages.join('. ') }.
             Fix error and try again."
           redirect_to request.referer
         end

--- a/app/models/file_import.rb
+++ b/app/models/file_import.rb
@@ -2,6 +2,16 @@ class FileImport < ApplicationRecord
   serialize :error, Array
 
   has_attached_file :file
-  validates_attachment :file, presence: true
-  validates_attachment_content_type :file, content_type: ['text/csv', 'text/plain']
+
+  validates_attachment :file, presence: true,
+    content_type: { content_type: 'text/csv' }
+
+  before_post_process :set_content_type
+
+  private
+
+  def set_content_type
+    mime_type = MIME::Types.type_for(file_file_name).first.to_s
+    file.instance_write(:content_type, mime_type)
+  end
 end

--- a/spec/controllers/spree/admin /product_imports_controller_spec.rb
+++ b/spec/controllers/spree/admin /product_imports_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Spree::Admin::ProductImportsController, type: :controller do
   stub_authorization!
 
   let(:valid_file) { file_fixture('valid_sample.csv').to_s }
+  let(:invalid_pdf_file) { file_fixture('invalid_pdf_file.pdf').to_s }
 
   describe '#create' do
     context 'when file is provided' do
@@ -20,15 +21,12 @@ RSpec.describe Spree::Admin::ProductImportsController, type: :controller do
         end
       end
 
-      # skipping this because Paperclip assigns 'text/plain'
-      # content type by default
-      # TODO: Research how to fix that default behaviour
-      xcontext 'when file content type is NOT text/csv' do
+      context 'when file content type is NOT text/csv' do
         it 'redirects to admin products page' do
-          plain_file = fixture_file_upload(valid_file, 'text/plain')
+          pdf_file = fixture_file_upload(invalid_pdf_file, 'text/pdf')
           request.env['HTTP_REFERER'] = admin_products_path
 
-          post :create, params: { file_import: { file: plain_file } }
+          post :create, params: { file_import: { file: pdf_file } }
 
           expect(response).to have_http_status(302)
           expect(response).to redirect_to(admin_products_path)


### PR DESCRIPTION
## This PR does the following:
- Set file content type before post-processing to override setting default content type
- Update specs

### Notes to the Reviewer:
- N/A

## Deployment process:
- N/A

## Screenshots:
- N/A